### PR TITLE
sourceTarget is always null

### DIFF
--- a/Fields/QueryableTreeList.cs
+++ b/Fields/QueryableTreeList.cs
@@ -74,7 +74,9 @@
 					string path = ExtractPath(value);
 					string parameters = ExtractParameters(value);
 
-					Item sourceTarget = this.GetItem().Axes.GetItem(path);
+					// FIX
+                    			// old: Item sourceTarget = this.GetItem().Axes.GetItem(path);
+            				Item sourceTarget = Sitecore.Context.ContentDatabase.Items[ItemID].Axes.SelectSingleItem(path);
 
 					if (sourceTarget != null)
 					{


### PR DESCRIPTION
sourceTarget is always null (Sitecore 7 and 8) because it points to the sitecore field and not the context item.